### PR TITLE
Keyboard scrolling fix

### DIFF
--- a/A2D2_iOS/A2D2_iOS.xcodeproj/project.pbxproj
+++ b/A2D2_iOS/A2D2_iOS.xcodeproj/project.pbxproj
@@ -608,7 +608,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.bespin.A2D2-iOSporg";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bespin.A2D2-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -631,7 +631,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.bespin.A2D2-iOSporg";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bespin.A2D2-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/A2D2_iOS/A2D2_iOS/Controllers/ViewControllers/RequestOptionsController.swift
+++ b/A2D2_iOS/A2D2_iOS/Controllers/ViewControllers/RequestOptionsController.swift
@@ -48,11 +48,9 @@ class RequestOptionsController: UIViewController, UIPickerViewDelegate, UIPicker
         if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue {
             let textViewOriginY = textView.frame.origin.y
             if textView.frame.origin.y == textViewOriginY && textView.isFirstResponder {
-//                self.view.frame.origin.y -= keyboardSize.height
                 if textView.frame.origin.y >= keyboardSize.height {
                     self.view.frame.origin.y -= keyboardSize.height/2
                 }
-                else { print("Do nothing, Chief") }
             }
         }
     }

--- a/A2D2_iOS/A2D2_iOS/Controllers/ViewControllers/RequestOptionsController.swift
+++ b/A2D2_iOS/A2D2_iOS/Controllers/ViewControllers/RequestOptionsController.swift
@@ -38,6 +38,30 @@ class RequestOptionsController: UIViewController, UIPickerViewDelegate, UIPicker
         locationManager.delegate = self
         nameField.delegate = self
         phoneNumberField.delegate = self
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    
+    @objc func keyboardWillShow(notification: NSNotification) {
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue {
+            let textViewOriginY = textView.frame.origin.y
+            if textView.frame.origin.y == textViewOriginY && textView.isFirstResponder {
+//                self.view.frame.origin.y -= keyboardSize.height
+                if textView.frame.origin.y >= keyboardSize.height {
+                    self.view.frame.origin.y -= keyboardSize.height/2
+                }
+                else { print("Do nothing, Chief") }
+            }
+        }
+    }
+    
+    
+    @objc func keyboardWillHide(notification: NSNotification) {
+        if self.view.frame.origin.y != 0 {
+            self.view.frame.origin.y = 0
+        }
     }
     
     


### PR DESCRIPTION
On compact devices (such as the iPhone 5s), we were having an issue where the keyboard would hide the textView (the Remarks field on Request Pickup Options) that the user was attempting to type in. We added code to move the textView up the screen if the keyboard would cover it otherwise.